### PR TITLE
Add critical-section dep to updated nrf52840 pac

### DIFF
--- a/pacs/nrf52840-pac/Cargo.toml
+++ b/pacs/nrf52840-pac/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 readme.workspace = true
 
 [dependencies]
+critical-section = { version = "1.0", optional = true }
 cortex-m.workspace = true
 vcell.workspace = true
 


### PR DESCRIPTION
Seems to be a new requirement from [svd2rust](https://docs.rs/svd2rust/latest/svd2rust/#target--cortex-m).